### PR TITLE
Add wheel-legged training setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# wheel-legged-robot
+# Wheel Legged Robot
+
+This repository contains a minimal setup for training a wheel-legged robot in Isaac Gym using a PPO algorithm and a simple PD controller.
+
+## Training
+
+The training script expects `stable-baselines3` and `isaacgym` to be installed. Run:
+
+```bash
+python src/train_wheel_legged.py --timesteps 1000000
+```
+
+The trained policy will be saved to `ppo_wheel_legged.zip` by default.

--- a/envs/wheel_legged_env.py
+++ b/envs/wheel_legged_env.py
@@ -1,0 +1,76 @@
+import gym
+import numpy as np
+
+try:
+    from isaacgym import gymapi
+except ImportError:  # Isaac Gym might not be installed in some environments
+    gymapi = None
+
+
+class PDController:
+    """Simple PD controller."""
+
+    def __init__(self, kp: float = 1.0, kd: float = 0.1):
+        self.kp = kp
+        self.kd = kd
+
+    def __call__(self, pos_error, vel_error):
+        return self.kp * pos_error + self.kd * vel_error
+
+
+class WheelLeggedEnv(gym.Env):
+    """Wrapper for the wheel-legged robot environment using Isaac Gym."""
+
+    metadata = {"render.modes": ["human"]}
+
+    def __init__(self, sim_cfg=None, controller: PDController | None = None):
+        super().__init__()
+        if gymapi is None:
+            raise ImportError("Isaac Gym is required to use WheelLeggedEnv")
+        self.sim_cfg = sim_cfg if sim_cfg is not None else {}
+        self.controller = controller if controller is not None else PDController()
+        # Placeholder observation and action spaces. Adjust according to robot model.
+        self.observation_space = gym.spaces.Box(
+            low=-np.inf, high=np.inf, shape=(24,), dtype=np.float32
+        )
+        self.action_space = gym.spaces.Box(
+            low=-1.0, high=1.0, shape=(12,), dtype=np.float32
+        )
+        self._create_sim()
+        self.reset()
+
+    def _create_sim(self):
+        """Create Isaac Gym simulator."""
+        self.gym = gymapi.acquire_gym()
+        sim_params = gymapi.SimParams()
+        self.sim = self.gym.create_sim(0, 0, gymapi.SimType.PHYSX, sim_params)
+        # Normally here we would load assets and set up the environment.
+
+    def reset(self, *, seed: int | None = None, options=None):  # noqa: D401
+        """Reset simulation and return initial observation."""
+        if seed is not None:
+            self.np_random, _ = gym.utils.seeding.np_random(seed)
+        # Reset the simulator state and robot here.
+        return self._get_obs()
+
+    def step(self, action):
+        # Convert action to desired joint positions and apply PD control.
+        pos_error = action  # placeholder
+        vel_error = np.zeros_like(action)
+        torques = self.controller(pos_error, vel_error)
+        # Apply torques to the robot in the simulator (placeholder)
+        obs = self._get_obs()
+        reward = 0.0
+        done = False
+        info = {}
+        return obs, reward, done, info
+
+    def render(self, mode="human"):
+        pass
+
+    def close(self):
+        if hasattr(self, "gym"):
+            self.gym.destroy_sim(self.sim)
+
+    def _get_obs(self):
+        return np.zeros(self.observation_space.shape, dtype=np.float32)

--- a/src/train_wheel_legged.py
+++ b/src/train_wheel_legged.py
@@ -1,0 +1,40 @@
+"""Training script for the wheel-legged robot using PPO."""
+
+import argparse
+
+import gym
+import numpy as np
+
+try:
+    from stable_baselines3 import PPO
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "stable-baselines3 is required to run the training script"
+    ) from exc
+
+from envs.wheel_legged_env import WheelLeggedEnv, PDController
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train PPO on Wheel-Legged Robot")
+    parser.add_argument("--timesteps", type=int, default=1_000_000, help="Number of training timesteps")
+    parser.add_argument("--kp", type=float, default=1.0, help="Proportional gain for PD controller")
+    parser.add_argument("--kd", type=float, default=0.1, help="Derivative gain for PD controller")
+    parser.add_argument("--save-path", type=str, default="ppo_wheel_legged.zip", help="Where to save the trained model")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    controller = PDController(kp=args.kp, kd=args.kd)
+    env = WheelLeggedEnv(controller=controller)
+
+    model = PPO("MlpPolicy", env, verbose=1)
+    model.learn(total_timesteps=args.timesteps)
+    model.save(args.save_path)
+
+    env.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a wheel-legged Isaac Gym environment wrapper
- add PPO training script using the PD controller
- document training in the README

## Testing
- `python -m py_compile envs/wheel_legged_env.py src/train_wheel_legged.py`


------
https://chatgpt.com/codex/tasks/task_e_68608eb54678832fac1c2f66bc486fd0